### PR TITLE
Pin pillow to 6.2.2 to support both py 2 and 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,9 +61,9 @@ class BuildExt(build_ext):
 setup(
     name='tiffrender',
     description='Tiff Renderer',
-    version='0.3.0',
-    setup_requires=['pybind11>=2.2.1', 'Pillow>=4.3.0'],
-    install_requires=['pybind11>=2.2.1', 'Pillow>=4.3.0'],
+    version='0.3.1',
+    setup_requires=['pybind11>=2.2.1', 'Pillow>=4.3.0,<=6.2.2'],
+    install_requires=['pybind11>=2.2.1', 'Pillow>=4.3.0,<=6.2.2'],
     ext_modules=ext_modules,
     cmdclass={'build_ext': BuildExt},
     test_suite='tests',


### PR DESCRIPTION
@woohp
Same as https://github.com/woohp/pdfrender/pull/1.